### PR TITLE
Adding additional padding to allow clicking card actions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,7 +79,7 @@ export default function Component() {
 
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100">
-      <div className="container mx-auto p-8 max-w-7xl">
+      <div className="container mx-auto p-8 pb-[8rem] max-w-7xl">
         <div className="flex justify-between items-center mb-12">
           <h1 className="text-4xl font-bold text-white">Monthly Subscriptions Tracker</h1>
           <Dialog open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION

### Category
Bugfix

### Overview
For long lists, the bottom bar overlaps with the cards so you can't click the actions anymore.

### Did you make the use of LLM/Code assistant?
No

### Screenshot _(if applicable)_
![image](https://github.com/user-attachments/assets/3015750f-3795-473b-a85d-9c0c35bad879)
